### PR TITLE
Update debug build output

### DIFF
--- a/Converter/FEZRepacker.Converter.csproj
+++ b/Converter/FEZRepacker.Converter.csproj
@@ -12,10 +12,6 @@
     <WarningLevel>0</WarningLevel>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugType>full</DebugType>
-  </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="System.Text.Json" Version="7.0.1" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />

--- a/Converter/FEZRepacker.Converter.csproj
+++ b/Converter/FEZRepacker.Converter.csproj
@@ -7,16 +7,13 @@
     
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    
+
+    <!-- TODO: Should we really have this at 0? -->
+    <WarningLevel>0</WarningLevel>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <DebugType>full</DebugType>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <WarningLevel>0</WarningLevel>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <WarningLevel>0</WarningLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Interface/FEZRepacker.Interface.csproj
+++ b/Interface/FEZRepacker.Interface.csproj
@@ -9,7 +9,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
-  <PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
     <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>

--- a/Interface/FEZRepacker.Interface.csproj
+++ b/Interface/FEZRepacker.Interface.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <ProduceReferenceAssembly>False</ProduceReferenceAssembly>
+    <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <PublishSingleFile>true</PublishSingleFile>
     <PublishTrimmed>true</PublishTrimmed>
   </PropertyGroup>


### PR DESCRIPTION
Update `Interface` build output to generate full debug information in debug configuration but produce a trimmed single-file executable in release. Also clean up `FEZRepacker.Converter.csproj` slightly. Doing this because Rider refuses to debug a single-file executable, plus there's no reason to use single-file in debug.