### PR TITLE
Fix serializing trile sets to json

### DIFF
--- a/Core/Helpers/Json/CustomConverters/QuaternionJsonConverter.cs
+++ b/Core/Helpers/Json/CustomConverters/QuaternionJsonConverter.cs
@@ -36,7 +36,13 @@ namespace FEZRepacker.Core.Helpers.Json.CustomConverters
             Quaternion quaternion,
             JsonSerializerOptions options)
         {
-            writer.WriteRawValue($"[{quaternion.X}, {quaternion.Y}, {quaternion.Z}, {quaternion.W}]");
+            // Preserve decimal places in JSON number by converting float value to decimal
+            writer.WriteStartArray();
+            writer.WriteNumberValue((decimal)quaternion.X);
+            writer.WriteNumberValue((decimal)quaternion.Y);
+            writer.WriteNumberValue((decimal)quaternion.Z);
+            writer.WriteNumberValue((decimal)quaternion.W);
+            writer.WriteEndArray();
         }
     }
 }

--- a/Core/Helpers/Json/CustomConverters/VectorJsonConverters.cs
+++ b/Core/Helpers/Json/CustomConverters/VectorJsonConverters.cs
@@ -33,7 +33,12 @@ namespace FEZRepacker.Core.Helpers.Json.CustomConverters
             Vector3 vector,
             JsonSerializerOptions options)
         {
-            writer.WriteRawValue($"[{vector.X}, {vector.Y}, {vector.Z}]");
+            // Preserve decimal places in JSON number by converting float value to decimal
+            writer.WriteStartArray();
+            writer.WriteNumberValue((decimal)vector.X);
+            writer.WriteNumberValue((decimal)vector.Y);
+            writer.WriteNumberValue((decimal)vector.Z);
+            writer.WriteEndArray();
         }
     }
 
@@ -63,7 +68,11 @@ namespace FEZRepacker.Core.Helpers.Json.CustomConverters
             Vector2 vector,
             JsonSerializerOptions options)
         {
-            writer.WriteRawValue($"[{vector.X}, {vector.Y}]");
+            // Preserve decimal places in JSON number by converting float value to decimal
+            writer.WriteStartArray();
+            writer.WriteNumberValue((decimal)vector.X);
+            writer.WriteNumberValue((decimal)vector.Y);
+            writer.WriteEndArray();
         }
     }
 }


### PR DESCRIPTION
This PR fixes a bug where JSON serialization of some of trile sets (i.e. untitled) stopped due to incorrect interpretation of real values. In original code, System.Text.Json failed to write a float string with comma (`0,123456`) instead of dot (`0.123456`).

It could be fixed with `CultureInfo.InvariantCulture`, but a solution is used by converting floats to decimals, thus preserving decimal places and writing JSON numbers with dot character.