### PR TITLE
Correctly serialize decimal total seconds of `TimeSpan` into a json number

### DIFF
--- a/Core/Helpers/Json/CustomConverters/TimeSpanJsonConverter.cs
+++ b/Core/Helpers/Json/CustomConverters/TimeSpanJsonConverter.cs
@@ -18,7 +18,7 @@ namespace FEZRepacker.Core.Helpers.Json.CustomConverters
             TimeSpan timespan,
             JsonSerializerOptions options)
         {
-            writer.WriteRawValue($"{timespan.TotalSeconds}");
+            writer.WriteNumberValue((decimal)timespan.TotalSeconds);
         }
     }
 }


### PR DESCRIPTION
Issue occurs then `JsonSerializer` tries to serialize a fractional duration of path segments in the level data.
This was detected on those levels:
* `pivot_three_cave`
* `lava_fork`
* `lava`
* `industrial_superspin`
* `villageville_2d`

Applied the same fix as in PR #24.